### PR TITLE
Parse Power Inductor "Rated Current" and "Saturation Current" Attributes

### DIFF
--- a/jlcparts/datatables.py
+++ b/jlcparts/datatables.py
@@ -77,7 +77,8 @@ def normalizeAttribute(key, value):
                  "Impulse Discharge Current (8/20us)", "Current - Gate Trigger (Igt) (Max)",
                  "Current - On State (It (AV)) (Max)", "Current - On State (It (RMS)) (Max)",
                  "Current - Supply (Max)", "Output Current", "Output Current (Max)",
-                 "Output / Channel Current", "Current - Output"]:
+                 "Output / Channel Current", "Current - Output",
+                 "Saturation Current (Isat)"]:
         value = attributes.currentAttribute(value)
     elif key in ["Power", "Power Per Element"]:
         value = attributes.powerAttribute(value)
@@ -141,7 +142,7 @@ def normalizeAttributeKey(key):
         key = "DC Resistance"
     if key in ["Insertion Loss ( dB Max )", "Insertion Loss (Max)"]:
         key = "Insertion Loss (dB Max)"
-    if key in ["Current Rating (Max)"]:
+    if key in ["Current Rating (Max)", "Rated Current"]:
         key = "Rated current"
     if key == "Power - Max":
         key = "Power"


### PR DESCRIPTION
For items in https://lcsc.com/products/Power-Inductors_544.html
Now parsed properly as current attributes, rather than strings

Example picture before:
![image](https://user-images.githubusercontent.com/3956920/143683140-60dd4a2c-e85e-45a5-bace-82fa988b4dc8.png)

After (now in sequence):
![image](https://user-images.githubusercontent.com/3956920/143683171-c0ab5548-f20c-45ab-a185-3bd4af63af67.png)
