### PR TITLE
Natural sorting of properties

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@discoveryjs/natural-compare": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",

--- a/web/src/componentTable.js
+++ b/web/src/componentTable.js
@@ -8,6 +8,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { SortableTable } from "./sortableTable"
 import { quantityComparator, quantityFormatter } from "./units";
 import { AttritionInfo, getQuantityPrice } from "./jlc"
+import { naturalCompare } from '@discoveryjs/natural-compare';
 
 enableMapSet();
 
@@ -37,7 +38,8 @@ function attributeComparator(x, y, valueType = undefined) {
     let comparator = quantityComparator(getQuantity(x.values[valueType]));
     return comparator(
         getValue(x.values[valueType]),
-        getValue(y.values[valueType]));
+        getValue(y.values[valueType])
+    );
 }
 
 function fullTextComponentsFilter(component, words) {
@@ -402,7 +404,7 @@ export class ComponentOverview extends React.Component {
                             <FontAwesomeIcon icon="file-pdf"/> {x.mfr}
                     </a>
                 </>,
-                comparator: (a, b) => a.mfr.localeCompare(b.mfr),
+                comparator: (a, b) => naturalCompare(a.mfr, b.mfr),
                 className: "px-1 whitespace-no-wrap"
             },
             {
@@ -435,7 +437,7 @@ export class ComponentOverview extends React.Component {
                         </a>
                     </>
                 },
-                comparator: (a, b) => a.lcsc.localeCompare(b.lcsc)
+                comparator: (a, b) => naturalCompare(a.lcsc, b.lcsc)
             },
             {
                 name: "Basic/Extended",

--- a/web/src/units.js
+++ b/web/src/units.js
@@ -1,3 +1,4 @@
+import { naturalCompare } from '@discoveryjs/natural-compare';
 
 // Return comparator for given quantity
 export function quantityComparator(quantityName) {
@@ -7,7 +8,7 @@ export function quantityComparator(quantityName) {
     ];
     if (numericQuantities.includes(quantityName))
         return numericComparator;
-    return (a, b) => String(a).localeCompare(String(b));
+    return naturalCompare;
 }
 
 // Return formatter for given quantity


### PR DESCRIPTION
Some values are messed up (ordered alphabetically), for example, 'Maximum Clamping Voltage' of 'Circuit Protection/TVS':
![obraz](https://user-images.githubusercontent.com/48691053/164945658-2215bd57-b674-4496-8d2f-e420353bc9cc.png)
I tried `localeCompare` with `{numeric: true}` and it was better but still not perfect:
![obraz](https://user-images.githubusercontent.com/48691053/164945730-4fc756d4-e31e-4872-b45f-d0d7685a3ff3.png)
I found `"@discoveryjs/natural-compare"` package and it seems to work just fine:
![obraz](https://user-images.githubusercontent.com/48691053/164945938-4bcb1f91-0bb4-49df-8e64-e39dc78e7ca5.png)