### PR TITLE
Fix high ram usage (#33)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jlcparts",
       "version": "0.1.0",
       "dependencies": {
+        "@discoveryjs/natural-compare": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-brands-svg-icons": "^5.14.0",
         "@fortawesome/free-regular-svg-icons": "^5.14.0",
@@ -16,7 +17,6 @@
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.5.0",
         "@testing-library/user-event": "^7.2.1",
-        "detect-browser": "^5.2.0",
         "dexie": "^3.0.2",
         "immer": "^7.0.8",
         "js-image-zoom": "^0.7.0",
@@ -1219,6 +1219,15 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
+    },
+    "node_modules/@discoveryjs/natural-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/natural-compare/-/natural-compare-1.0.0.tgz",
+      "integrity": "sha512-Pq35vJMxLZq4whZhyaMGO/89mmFee2+6NojaXD2bNo+7CxI6P7C1tncgQ0CM60+WueRMr8uFDKSX/8KitImCQg==",
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "0.2.30",
@@ -5234,11 +5243,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "node_modules/detect-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
-      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
     },
     "node_modules/detect-newline": {
       "version": "2.1.0",
@@ -18414,6 +18418,11 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@discoveryjs/natural-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/natural-compare/-/natural-compare-1.0.0.tgz",
+      "integrity": "sha512-Pq35vJMxLZq4whZhyaMGO/89mmFee2+6NojaXD2bNo+7CxI6P7C1tncgQ0CM60+WueRMr8uFDKSX/8KitImCQg=="
+    },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.30",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz",
@@ -21820,11 +21829,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "detect-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
-      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
     },
     "detect-newline": {
       "version": "2.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,6 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
-    "detect-browser": "^5.2.0",
     "dexie": "^3.0.2",
     "immer": "^7.0.8",
     "js-image-zoom": "^0.7.0",

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -16,10 +16,6 @@ import { updateComponentLibrary, checkForComponentLibraryUpdate, db } from './db
 import { ComponentOverview } from './componentTable'
 import { History } from './history'
 
-import { detect } from 'detect-browser';
-
-const browser = detect();
-
 
 library.add(fas, far, fab);
 
@@ -72,25 +68,6 @@ function Footer(props) {
   return <div className="w-full p-2 border-t-2 border-gray-800" style={{"minHeight": "200px"}}>
 
   </div>
-}
-
-function FFNote(props) {
-  if (browser && browser.name === "firefox")
-    return <div className="w-full p-8 my-2 bg-yellow-400 rounded">
-      <p className="font-bold">
-        It seems that you use Firefox. Unfortunately, we experience functionality
-        problems in Firefox. Please, use other browser until we resolve this issue.
-      </p>
-      <p>
-        See the corresponding &nbsp;
-          <a href="https://github.com/yaqwsx/jlcparts/issues/33" className="underline text-blue-600">
-            Github issue
-          </a>&nbsp;
-        for more information and details.
-      </p>
-    </div>
-
-  return <></>
 }
 
 class FirstTimeNote extends React.Component {
@@ -300,7 +277,6 @@ class App extends React.Component {
           <UpdateBar onTriggerUpdate={this.triggerUpdate}/>
           <Header/>
           <FirstTimeNote/>
-          <FFNote/>
           <NewComponentFormatWarning/>
           <Navbar/>
               <Switch>


### PR DESCRIPTION
Attempt to fix browser crash by filtering text on the database side.
Crashes are likely caused by excessive memory usage.
`query.filter()` limits RAM usage caused by `query.toArray()`
Previous queries are now aborted so that less memory is used and the performance is better.
I set 3 characters as the minimum when searching all categories.
Tested on Chrome and Firefox