### PR TITLE
Parallelize buildtables & update readme

### DIFF
--- a/.github/workflows/update_components.yaml
+++ b/.github/workflows/update_components.yaml
@@ -54,7 +54,8 @@ jobs:
           jlcparts getlibrary --age 10000 \
                               --limit 30000 \
                               parts.csv cache.sqlite3
-          jlcparts buildtables --ignoreoldstock 120 \
+          jlcparts buildtables --jobs 0 \
+                               --ignoreoldstock 120 \
                                cache.sqlite3 web/build/data
 
           rm -f web/build/data/cache.z*

--- a/README.md
+++ b/README.md
@@ -73,12 +73,10 @@ $ pip install -e .
 Then to download the cached parts list and process it, run:
 
 ```
-$ wget https://yaqwsx.github.io/jlcparts/data/cache.zip 
-$ wget https://yaqwsx.github.io/jlcparts/data/cache.z01
-$ wget https://yaqwsx.github.io/jlcparts/data/cache.z02
+$ wget https://yaqwsx.github.io/jlcparts/data/cache.zip https://yaqwsx.github.io/jlcparts/data/cache.z0{1..8}
 $ 7z x cache.zip
 $ mkdir -p web/public/data/
-$ jlcparts buildtables cache.sqlite3 web/public/data
+$ jlcparts buildtables --jobs 0 --ignoreoldstock 30 cache.sqlite3 web/public/data
 ```
 
 To launch the frontend web server, run:


### PR DESCRIPTION
1. the readme needed to be updated for the current cache size
2. building the tables failed for me due to `ValueError: could not convert string to float: '11.5u;12.5'` in C3606553. Data quality has never been JLCPCB's strong suit, so I've changed the readme to suggest using `--ignoreoldstock 30` which is likely more useful anyway.
3. I've added parallelization of the table creation. This was very easy to parallelize, and I wanted to use all my cores.
    - `--jobs 1 --ignoreoldstock 30`: 75.08s user 3.66s system 100% cpu 1:18.40 total
    - `--jobs 16 --ignoreoldstock 30`: 122.83s user 7.66s system 638% cpu 20.422 total
    - original, `--ignoreoldstock 30`: 72.10s user 3.37s system 100% cpu 1:15.27 total