### PR TITLE
Use SQLite for parts database

### DIFF
--- a/.github/workflows/update_components.yaml
+++ b/.github/workflows/update_components.yaml
@@ -54,7 +54,8 @@ jobs:
           jlcparts getlibrary --age 10000 \
                               --limit 30000 \
                               parts.csv cache.sqlite3
-          jlcparts buildtables --ignoreoldstock 120 \
+          jlcparts buildtables --jobs 0 \
+                               --ignoreoldstock 120 \
                                cache.sqlite3 web/build/data
 
           rm -f web/build/data/cache.z*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+*.sqlite*
+.idea
+*.zip
+*.z*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -73,12 +73,10 @@ $ pip install -e .
 Then to download the cached parts list and process it, run:
 
 ```
-$ wget https://yaqwsx.github.io/jlcparts/data/cache.zip 
-$ wget https://yaqwsx.github.io/jlcparts/data/cache.z01
-$ wget https://yaqwsx.github.io/jlcparts/data/cache.z02
+$ wget https://yaqwsx.github.io/jlcparts/data/cache.zip https://yaqwsx.github.io/jlcparts/data/cache.z0{1..8}
 $ 7z x cache.zip
 $ mkdir -p web/public/data/
-$ jlcparts buildtables cache.sqlite3 web/public/data
+$ jlcparts buildtables --jobs 0 --ignoreoldstock 30 cache.sqlite3 web/public/data
 ```
 
 To launch the frontend web server, run:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ pip install -e .
 Then to download the cached parts list and process it, run:
 
 ```
-$ wget https://yaqwsx.github.io/jlcparts/data/cache.zip https://yaqwsx.github.io/jlcparts/data/cache.z0{1..8}
+$ echo https://yaqwsx.github.io/jlcparts/data/cache.zip https://yaqwsx.github.io/jlcparts/data/cache.z{01..19} | tr ' ' '\n' | aria2c --input-file=-
 $ 7z x cache.zip
 $ mkdir -p web/public/data/
 $ jlcparts buildtables --jobs 0 --ignoreoldstock 30 cache.sqlite3 web/public/data

--- a/jlcparts/datatables.py
+++ b/jlcparts/datatables.py
@@ -1,17 +1,25 @@
 import dataclasses
-import re
-import os
-import shutil
-import json
-import datetime
 import gzip
+import itertools
+import json
 import multiprocessing
+from multiprocessing.shared_memory import SharedMemory
+import os
+import random
+import shutil
+import sqlite3
+import struct
+import textwrap
 from pathlib import Path
+from typing import Dict, Generator, Optional
 
 import click
-from jlcparts.partLib import PartLibraryDb
-from jlcparts.common import sha256file
+import pyzstd
+
 from jlcparts import attributes, descriptionAttributes
+from jlcparts.common import sha256file
+from jlcparts.partLib import PartLibraryDb
+
 
 def saveJson(object, filename, hash=False, pretty=False, compress=False):
     openFn = gzip.open if compress else open
@@ -202,7 +210,7 @@ def trimLcscUrl(url, lcsc):
 
 def extractComponent(component, schema):
     try:
-        propertyList = []
+        result: Dict[str, Optional[str]] = {}
         for schItem in schema:
             if schItem == "attributes":
                 # The cache might be in the old format
@@ -233,31 +241,31 @@ def extractComponent(component, schema):
                 attr["Manufacturer"] = component.get("manufacturer", None)
 
                 attr = dict([normalizeAttribute(key, val) for key, val in attr.items()])
-                propertyList.append(attr)
+                result[schItem] = json.dumps(attr)
             elif schItem == "img":
                 images = component.get("extra", {}).get("images", None)
-                propertyList.append(crushImages(images))
+                result[schItem] = crushImages(images)
             elif schItem == "url":
                 url = component.get("extra", {}).get("url", None)
-                propertyList.append(trimLcscUrl(url, component["lcsc"]))
+                result[schItem] = trimLcscUrl(url, component["lcsc"])
             elif schItem in component:
                 item = component[schItem]
                 if isinstance(item, str):
                     item = item.strip()
-                propertyList.append(item)
+                else:
+                    item = json.dumps(item)
+                result[schItem] = item
             else:
-                propertyList.append(None)
-        return propertyList
+                result[schItem] = None
+        return result
     except Exception as e:
         raise RuntimeError(f"Cannot extract {component['lcsc']}").with_traceback(e.__traceback__)
 
-def buildDatatable(components):
+
+def buildDatatable(components) -> Generator[Dict[str, str], None, None]:
     schema = ["lcsc", "mfr", "joints", "description",
-              "datasheet", "price", "img", "url", "attributes"]
-    return {
-        "schema": schema,
-        "components": [extractComponent(x, schema) for x in components]
-    }
+              "datasheet", "price", "img", "url", "attributes", "stock"]
+    return (extractComponent(component, schema) for component in components)
 
 def buildStocktable(components):
     return {component["lcsc"]: component["stock"] for component in components }
@@ -274,6 +282,39 @@ def clearDir(directory):
             shutil.rmtree(file_path)
 
 
+def _sqlite_fast_cur(path: str) -> sqlite3.Cursor:
+    conn = sqlite3.connect(path, isolation_level=None)
+    cursor = conn.cursor()
+    # very dangerous, but we don't care about data integrity here. Recovery is to
+    # delete the whole database and rebuild.
+    cursor.execute("PRAGMA journal_mode=OFF;")
+    cursor.execute("PRAGMA synchronous=OFF;")
+    return cursor
+
+
+INIT_TABLES_SQL = textwrap.dedent("""\
+    CREATE TABLE categories
+    (
+        id          INTEGER PRIMARY KEY NOT NULL,
+        category    TEXT NOT NULL,
+        subcategory TEXT NOT NULL,
+        UNIQUE (category, subcategory)
+    );
+    CREATE TABLE component
+    (
+        lcsc        TEXT PRIMARY KEY NOT NULL,
+        category_id INTEGER          NOT NULL REFERENCES categories (id),
+        mfr         TEXT             NOT NULL,
+        joints      INTEGER          NOT NULL,
+        description TEXT             NOT NULL,
+        datasheet   TEXT             NOT NULL,
+        price       TEXT             NOT NULL, -- JSON
+        img         TEXT,
+        url         TEXT,
+        attributes  TEXT             NOT NULL, -- JSON
+        stock       INTEGER          NOT NULL
+    );""")
+
 @dataclasses.dataclass
 class MapCategoryParams:
     libraryPath: str
@@ -284,6 +325,7 @@ class MapCategoryParams:
     subcatName: str
 
 
+_map_category_cur = None
 def _map_category(val: MapCategoryParams):
     # Sometimes, JLC PCB doesn't fill in the category names. Ignore such
     # components.
@@ -292,37 +334,159 @@ def _map_category(val: MapCategoryParams):
     if val.subcatName.strip() == "":
         return None
 
-    filebase = val.catName + val.subcatName
-    filebase = filebase.replace("&", "and").replace("/", "aka")
-    filebase = re.sub('[^A-Za-z0-9]', '_', filebase)
+    # each process gets its own database, then we merge them at the end and add indexes
+    # we do this because SQLite doesn't do a good job with concurrent writes and ends up
+    # getting stuck on locks
+    global _map_category_cur
+    if _map_category_cur is None:
+        _map_category_cur = _sqlite_fast_cur(os.path.join(val.outdir, f"part_${os.getpid()}.sqlite3"))
+        _map_category_cur.executescript(INIT_TABLES_SQL)
+    cur = _map_category_cur
 
     lib = PartLibraryDb(val.libraryPath)
-    components = lib.getCategoryComponents(val.catName, val.subcatName, stockNewerThan=val.ignoreoldstock)
+    components = lib.getCategoryComponents(val.catName, val.subcatName,
+                                           stockNewerThan=val.ignoreoldstock)
 
-    dataTable = buildDatatable(components)
-    dataTable.update({"category": val.catName, "subcategory": val.subcatName})
-    dataHash = saveJson(dataTable, os.path.join(val.outdir, f"{filebase}.json.gz"),
-                        hash=True, compress=True)
+    categoryId = random.randint(0, 2**31 - 1)
+    insertCategory = textwrap.dedent("""\
+        INSERT INTO categories (id, category, subcategory)
+        VALUES ($id, $category, $subcategory)""")
+    cur.execute(
+        insertCategory,
+        {
+            "id": categoryId,
+            "category": val.catName,
+            "subcategory": val.subcatName
+        })
 
-    stockTable = buildStocktable(components)
-    stockHash = saveJson(stockTable, os.path.join(val.outdir, f"{filebase}.stock.json"), hash=True)
+    insertComponent = textwrap.dedent("""\
+        INSERT INTO component (lcsc, category_id, mfr, joints, description, datasheet, price, img, url,
+                               attributes, stock)
+        VALUES ($lcsc, $category_id, $mfr, $joints, $description, $datasheet, $price, $img, $url,
+                $attributes, $stock)""")
+    dataIter = ({
+        **component,
+        "category_id": categoryId,
+    } for component in buildDatatable(components))
+
+    while batch := list(itertools.islice(dataIter, 200)):
+        cur.executemany(insertComponent, batch)
+        cur.connection.commit()
 
     return {
         "catName": val.catName,
         "subcatName": val.subcatName,
-        "sourcename": filebase,
-        "datahash": dataHash,
-        "stockhash": stockHash
     }
+
+def compressChunkGzip(c):
+    return (c, gzip.compress(c))
+
+def pagedCompressFileGzip(inputPath, pageSize=1024, jobs=1):
+    with open(inputPath, 'rb') as infile, \
+            open(f"{inputPath}.gzpart", 'wb') as outfile, \
+            open(f"{inputPath}.gzindex", 'wb') as indexfile:
+        dataPos = 0
+        compPos = 0
+
+        # magic number to indicate index format.
+        indexfile.write(struct.pack('<QQ', 0xb6d881b0d2f0408e, 0x9c7649381fe30e8c))
+
+        totalChunks = os.path.getsize(inputPath) // pageSize
+        with multiprocessing.Pool(jobs or multiprocessing.cpu_count()) as pool:
+
+            chunkIter = iter(lambda: infile.read(pageSize), b'')
+            for i, (chunk, compressedChunk) in enumerate(pool.imap(compressChunkGzip, chunkIter, chunksize=100)):
+                if i % (16*1024) == 0:
+                    print(f"{i / totalChunks * 100:.0f} % compressed")
+                outfile.write(compressedChunk)
+                indexfile.write(struct.pack('<LL', dataPos, compPos))
+                dataPos += len(chunk)
+                compPos += len(compressedChunk)
+
+            # write last index entry to simplify index reading logic.
+            indexfile.write(struct.pack('<LL', dataPos, compPos))
+
+def compressChunkZstd(args):
+    c, sharedDictName = args
+    try:
+        sharedDict = SharedMemory(name=sharedDictName)
+        zstdDict = pyzstd.ZstdDict(sharedDict.buf)
+        return (c, pyzstd.compress(c,  6, zstd_dict=zstdDict))
+    finally:
+        sharedDict.close()
+
+
+def pagedCompressFileZstd(inputPath, pageSize=1024, jobs=1, dictSize=16*1024):
+    def trainDict():
+        fileSize = os.path.getsize(inputPath)
+        trainingChunkSize = 256 * 1024
+        trainingSamplesCount = 32
+        step = (fileSize - trainingChunkSize) // (trainingSamplesCount - 1)
+        trainingSamples = []
+
+        with open(inputPath, 'rb') as file:
+            for offset in range(0, fileSize, step):
+                file.seek(offset)
+                trainingSamples.append(file.read(trainingChunkSize))
+
+        zstdDict = pyzstd.train_dict(trainingSamples, dict_size=dictSize)
+        zstdDict = pyzstd.finalize_dict(zstdDict, trainingSamples, dict_size=dictSize, level=6)
+        return zstdDict
+
+
+    with open(inputPath, 'rb') as infile, \
+            open(f"{inputPath}.zstpart", 'wb') as outfile, \
+            open(f"{inputPath}.zstindex", 'wb') as indexfile:
+        dataPos = 0
+        compPos = 0
+
+        print("Training dictionary...")
+        zstdDict = trainDict()
+
+        # magic number to indicate index format.
+        indexfile.write(struct.pack('<QQ', 0x0f4b462afc1e47fc, 0xb6ee9b384955469b))
+        indexfile.write(zstdDict.dict_content)
+
+        try:
+            sharedDict = SharedMemory(create=True, size=len(zstdDict.dict_content))
+            sharedDict.buf[:] = zstdDict.dict_content
+            sharedDictName = sharedDict.name
+
+            totalChunks = os.path.getsize(inputPath) // pageSize
+            with multiprocessing.Pool(jobs or multiprocessing.cpu_count()) as pool:
+
+                args = ((chunk, sharedDictName) for chunk in iter(lambda: infile.read(pageSize), b''))
+                for i, (chunk, compressedChunk) in enumerate(pool.imap(compressChunkZstd, args, chunksize=100)):
+                    if i % (16*1024) == 0:
+                        print(f"{i / totalChunks * 100:.0f} % compressed")
+                    outfile.write(compressedChunk)
+                    indexfile.write(struct.pack('<LL', dataPos, compPos))
+                    dataPos += len(chunk)
+                    compPos += len(compressedChunk)
+
+                # write last index entry to simplify index reading logic.
+                indexfile.write(struct.pack('<LL', dataPos, compPos))
+        finally:
+            sharedDict.close()
+            sharedDict.unlink()
+
 
 @click.command()
 @click.argument("library", type=click.Path(dir_okay=False))
 @click.argument("outdir", type=click.Path(file_okay=False))
 @click.option("--ignoreoldstock", type=int, default=None,
-    help="Ignore components that weren't on stock for more than n days")
+              help="Ignore components that weren't on stock for more than n days")
 @click.option("--jobs", type=int, default=1,
-    help="Number of parallel processes. Defaults to 1, set to 0 to use all cores")
-def buildtables(library, outdir, ignoreoldstock, jobs):
+              help="Number of parallel processes. Set to 0 to use all cores")
+@click.option("--pagesize", type=int, default=1024,
+              help="Page size for the compressed database")
+@click.option("--dictsize", type=int, default=16 * 1024,
+              help="Dictionary size for the compressed database")
+@click.option('--compression-algorithm', type=click.Choice(['zstd', 'gzip', 'none']),
+              default='zstd',
+              help="Compression algorithm to use")
+def buildtables(library, outdir, ignoreoldstock, jobs, pagesize, dictsize,
+                compression_algorithm):
     """
     Build datatables out of the LIBRARY and save them in OUTDIR
     """
@@ -330,9 +494,8 @@ def buildtables(library, outdir, ignoreoldstock, jobs):
     Path(outdir).mkdir(parents=True, exist_ok=True)
     clearDir(outdir)
 
-
-    total = lib.countCategories()
-    categoryIndex = {}
+    outputDb = _sqlite_fast_cur(os.path.join(outdir, "index.sqlite3"))
+    outputDb.executescript(INIT_TABLES_SQL)
 
     params = []
     for (catName, subcategories) in lib.categories().items():
@@ -341,22 +504,60 @@ def buildtables(library, outdir, ignoreoldstock, jobs):
                 libraryPath=library, outdir=outdir, ignoreoldstock=ignoreoldstock,
                 catName=catName, subcatName=subcatName))
 
-    with multiprocessing.Pool(jobs or multiprocessing.cpu_count()) as pool:
-        for i, result in enumerate(pool.imap_unordered(_map_category, params)):
-            if result is None:
-                continue
-            catName, subcatName = result["catName"], result["subcatName"]
-            print(f"{((i) / total * 100):.2f} % {catName}: {subcatName}")
-            if catName not in categoryIndex:
-                categoryIndex[catName] = {}
-            assert subcatName not in categoryIndex[catName]
-            categoryIndex[catName][subcatName] = {
-                "sourcename": result["sourcename"],
-                "datahash": result["datahash"],
-                "stockhash": result["stockhash"]
-            }
-    index = {
-        "categories": categoryIndex,
-        "created": datetime.datetime.now().astimezone().replace(microsecond=0).isoformat()
-    }
-    saveJson(index, os.path.join(outdir, "index.json"), hash=True)
+    total = lib.countCategories()
+
+    def report_progress(i, result):
+        if result is None:
+            return
+        catName, subcatName = result["catName"], result["subcatName"]
+        print(f"{((i) / total * 100):.1f} % {catName}: {subcatName}")
+
+    if jobs == 1:
+        # do everything in the main thread in this case to make debugging easier
+        for i, param in enumerate(params):
+            report_progress(i, _map_category(param))
+    else:
+        with multiprocessing.Pool(jobs or multiprocessing.cpu_count()) as pool:
+            for i, result in enumerate(pool.imap_unordered(_map_category, params)):
+                report_progress(i, result)
+
+    outputDb.execute(f"pragma page_size = {pagesize};")
+
+    # merge all databases
+    print("Merging databases...")
+    for i, filename in enumerate(os.listdir(outdir)):
+        if not filename.startswith("part_"):
+            continue
+        filepath = os.path.join(outdir, filename)
+        outputDb.execute(f"ATTACH DATABASE '{filepath}' AS db{i};")
+        # happens fully in native code and is very fast
+        outputDb.execute(f"INSERT INTO main.categories SELECT * FROM db{i}.categories;")
+        outputDb.execute(f"INSERT INTO main.component SELECT * FROM db{i}.component;")
+        outputDb.execute(f"DETACH DATABASE db{i};")
+        os.unlink(filepath)
+
+    print("Building indexes...")
+    # create indexes after all data is inserted to speed up the process
+    outputDb.executescript("""\
+CREATE INDEX component_mfr ON component (mfr);
+CREATE INDEX categories_category ON categories (category);
+CREATE INDEX categories_subcategory ON categories (subcategory);
+""")
+
+    # optimize db: https://github.com/phiresky/sql.js-httpvfs#usage
+    print("Optimizing database...")
+    outputDb.execute("pragma journal_mode = delete;")
+    outputDb.execute("vacuum;")
+    outputDb.connection.close()
+
+    print("Compressing database...")
+    if compression_algorithm == 'gzip':
+        pagedCompressFileGzip(
+            os.path.join(outdir, "index.sqlite3"),
+            pageSize=pagesize)
+    elif compression_algorithm == 'zstd':
+        pagedCompressFileZstd(
+            os.path.join(outdir, "index.sqlite3"),
+            pageSize=pagesize,
+            jobs=jobs,
+            dictSize=dictsize)


### PR DESCRIPTION
The intent here is to use this with https://github.com/phiresky/sql.js-httpvfs. There are major missing pieces:

- the python sqlite on my system doesn't have the fts5 extension availible, so while sql.js-httpvfs theoretically supports full-text search, it is not available
- the sql.js-httpvfs VFS needs to be modified to download the index file and map between the index & the gzipped data, and use the Compression Streams API to decompress each chunk
- no work was done on the frontend portion of jlcparts

Quick benchmarks:

algo | page size (KiB) | zstd dict (KiB) | compressed (MiB) | uncompressed (MiB) | ratio | cpu (s) | compression cpu (s)
-- | -- | -- | -- | -- | -- | -- | --
zstd | 1 | 8 | 111 | 537 | 21 | 99 | 45
zstd | 2 | 8 | 96 | 566 | 17 | 82 | 28
zstd | 4 | 8 | 74 | 634 | 12 | 74 | 20
zstd | 8 | 8 | 54 | 545 | 10 | 64 | 10
zstd | 16 | 8 | 42 | 513 | 8 | 62 | 8
zstd | 1 | 16 | 104 | 537 | 19 | 130 | 76
zstd | 2 | 16 | 89 | 566 | 16 | 98 | 44
zstd | 4 | 16 | 71 | 634 | 11 | 81 | 27
zstd | 8 | 16 | 51 | 545 | 9 | 68 | 14
zstd | 16 | 16 | 41 | 513 | 8 | 62 | 8
zstd | 1 | 32 | 98 | 537 | 18 | 205 | 151
zstd | 2 | 32 | 80 | 566 | 14 | 139 | 85
zstd | 4 | 32 | 68 | 634 | 11 | 103 | 49
zstd | 8 | 32 | 49 | 545 | 9 | 78 | 24
zstd | 16 | 32 | 40 | 513 | 8 | 67 | 13
zstd | 1 | 64 | 87 | 537 | 16 | 313 | 259
zstd | 2 | 64 | 73 | 566 | 13 | 202 | 148
zstd | 4 | 64 | 59 | 634 | 9 | 136 | 82
zstd | 8 | 64 | 46 | 545 | 8 | 93 | 39
zstd | 16 | 64 | 38 | 513 | 7 | 75 | 21
zstd | 1 | 128 | 85 | 537 | 16 | 2696 | 2642
zstd | 2 | 128 | 71 | 566 | 13 | 1452 | 1398
zstd | 4 | 128 | 58 | 634 | 9 | 765 | 711
zstd | 8 | 128 | 46 | 545 | 8 | 392 | 338
zstd | 16 | 128 | 38 | 513 | 7 | 206 | 152
zstd | 1 | 256 | 84 | 537 | 16 | 4318 | 4264
zstd | 2 | 256 | 70 | 566 | 12 | 2101 | 2047
zstd | 4 | 256 | 58 | 634 | 9 | 1115 | 1061
zstd | 8 | 256 | 51 | 545 | 9 | 841 | 787
zstd | 16 | 256 | 55 | 513 | 11 | 60 | 6
none | 1 |   |   | 537 |   | 54 | 0
none | 2 |   |   | 566 |   | 53 | 0
none | 4 |   |   | 634 |   | 54 | 0
none | 8 |   |   | 545 |   | 53 | 0
none | 16 |   |   | 513 |   | 54 | 0
gzip | 1 |   | 198 | 537 | 37 | 83 | 29
gzip | 2 |   | 164 | 566 | 29 | 69 | 15
gzip | 4 |   | 122 | 634 | 19 | 66 | 12
gzip | 8 |   | 78 | 545 | 14 | 61 | 7
gzip | 16 |   | 56 | 513 | 11 | 62 | 8


note: not super helpful in the CPU & time area because I have not tested read performance.


See https://github.com/yaqwsx/jlcparts/issues/37
