### PR TITLE
Allow fetch requests to read from a single downloaded tar.gz file

### DIFF
--- a/jlcparts/datatables.py
+++ b/jlcparts/datatables.py
@@ -13,6 +13,9 @@ from jlcparts.partLib import PartLibraryDb
 from jlcparts.common import sha256file
 from jlcparts import attributes, descriptionAttributes
 
+import tarfile
+import glob
+
 def saveJson(object, filename, hash=False, pretty=False, compress=False):
     openFn = gzip.open if compress else open
     with openFn(filename, "wt", encoding="utf-8") as f:
@@ -25,6 +28,14 @@ def saveJson(object, filename, hash=False, pretty=False, compress=False):
             hash = sha256file(filename)
             f.write(hash)
         return hash
+    
+def saveAllDataArchive(path):
+    patterns = ['*.json', '*.json.gz', '*.sha256']
+
+    with tarfile.open(os.path.join(path, 'all-data.tar.gz'), 'w:gz') as tar:
+        for pattern in patterns:
+            for file in glob.glob(os.path.join(path, pattern)):
+                tar.add(file, arcname=os.path.relpath(file, start=path))
 
 def weakUpdateParameters(attrs, newParameters):
     for attr, value in newParameters.items():
@@ -382,3 +393,4 @@ def buildtables(library, outdir, ignoreoldstock, jobs):
         "created": datetime.datetime.now().astimezone().replace(microsecond=0).isoformat()
     }
     saveJson(index, os.path.join(outdir, "index.json"), hash=True)
+    saveAllDataArchive(outdir)

--- a/jlcparts/datatables.py
+++ b/jlcparts/datatables.py
@@ -15,6 +15,7 @@ from jlcparts import attributes, descriptionAttributes
 
 import tarfile
 import glob
+import random
 
 def saveJson(object, filename, hash=False, pretty=False, compress=False):
     openFn = gzip.open if compress else open
@@ -32,10 +33,14 @@ def saveJson(object, filename, hash=False, pretty=False, compress=False):
 def saveAllDataArchive(path):
     patterns = ['*.json', '*.json.gz', '*.sha256']
 
-    with tarfile.open(os.path.join(path, 'all-data.tar.gz'), 'w:gz') as tar:
-        for pattern in patterns:
-            for file in glob.glob(os.path.join(path, pattern)):
-                tar.add(file, arcname=os.path.relpath(file, start=path))
+    with tarfile.open(os.path.join(path, 'all-data-1.tar.gz'), 'w:gz') as tar1:
+        with tarfile.open(os.path.join(path, 'all-data-2.tar.gz'), 'w:gz') as tar2:
+            for pattern in patterns:
+                for file in glob.glob(os.path.join(path, pattern)):
+                    if random.randint(1, 2) == 1:
+                        tar1.add(file, arcname=os.path.relpath(file, start=path))
+                    else:
+                        tar2.add(file, arcname=os.path.relpath(file, start=path))
 
 def weakUpdateParameters(attrs, newParameters):
     for attr, value in newParameters.items():

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
         "@testing-library/user-event": "^7.2.1",
         "dexie": "^3.0.2",
         "immer": "^7.0.8",
+        "js-untar": "^2.0.0",
         "pako": "^2.0.4",
         "react": "^16.13.1",
         "react-copy-to-clipboard": "^5.0.2",
@@ -13864,6 +13865,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/js-untar": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/js-untar/-/js-untar-2.0.0.tgz",
+      "integrity": "sha512-7CsDLrYQMbLxDt2zl9uKaPZSdmJMvGGQ7wo9hoB3J+z/VcO2w63bXFgHVnjF1+S9wD3zAu8FBVj7EYWjTQ3Z7g=="
     },
     "node_modules/js-yaml": {
       "version": "3.14.0",
@@ -29778,6 +29784,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "js-untar": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/js-untar/-/js-untar-2.0.0.tgz",
+      "integrity": "sha512-7CsDLrYQMbLxDt2zl9uKaPZSdmJMvGGQ7wo9hoB3J+z/VcO2w63bXFgHVnjF1+S9wD3zAu8FBVj7EYWjTQ3Z7g=="
     },
     "js-yaml": {
       "version": "3.14.0",

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "@testing-library/user-event": "^7.2.1",
     "dexie": "^3.0.2",
     "immer": "^7.0.8",
+    "js-untar": "^2.0.0",
     "pako": "^2.0.4",
     "react": "^16.13.1",
     "react-copy-to-clipboard": "^5.0.2",

--- a/web/src/db.js
+++ b/web/src/db.js
@@ -106,17 +106,22 @@ export async function checkForComponentLibraryUpdate() {
 let allData = {
     filesPromise: null,
     fetchSingle: async function(url) {  // fetchs a single chunk of the combined files
-        const resp = await fetch(url);
-        if (resp.status === 200) {
-            const compressedData = await resp.arrayBuffer();
-            const data = pako.ungzip(compressedData);
-            const files = await untar(data.buffer);                            
-            const fileData = {};
-            for (const file of files) {
-                fileData[`${SOURCE_PATH}/${file.name}`.toLowerCase()] = file.buffer;
+        try {
+            const resp = await fetch(url);
+            if (resp.status === 200) {
+                const compressedData = await resp.arrayBuffer();
+                const data = pako.ungzip(compressedData);
+                const files = await untar(data.buffer);                            
+                const fileData = {};
+                for (const file of files) {
+                    fileData[`${SOURCE_PATH}/${file.name}`.toLowerCase()] = file.buffer;
+                }
+                return fileData;
+            } else {
+                return {};  // failed to download/unpack
             }
-            return fileData;
-        } else {
+        } catch (ex) {
+            console.log('Failed to fetch all-data.tar.gz', ex);
             return {};  // failed to download/unpack
         }
     },
@@ -137,10 +142,7 @@ let allData = {
                             resolve(null);
                         }
                     } catch(ex) {
-                        //reject(ex);
                         resolve(null);
-
-                        console.log('Failed to fetch all-data.tar.gz', ex);
                     }                
                 });
             }


### PR DESCRIPTION
This PR allows all fetch requests to read from a single downloaded _**all-data.tar.gz**_ file, rather than making thousands of parallel network requests. This file is made at the same time as the rest of the data, and is simply tar gzip of the data folder (*.json, *.json.gz, *.sha256 files).

Falls back to individual fetch requests if the archive file is unavailable, or if the requested file is not within the archive.