### PR TITLE
Fix build space?

### DIFF
--- a/.github/workflows/update_components.yaml
+++ b/.github/workflows/update_components.yaml
@@ -10,14 +10,20 @@ jobs:
     runs-on: ubuntu-22.04
     environment: github-pages
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             python3 python3-pip nodejs npm wget zip unzip p7zip-full
           sudo pip3 install requests click
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Build frontend
         run: |
           cd web


### PR DESCRIPTION
I can't run this myself, but this should fix #132 - and the fix is the same as Bouni/kicad-jlcpcb-tools#492 / Bouni/kicad-jlcpcb-tools#498.

This:
- install the requirements first
- then [maximizes disk space](https://github.com/easimon/maximize-build-space?tab=readme-ov-file#usage) (remove optionally installed, and unused things - e.g. mono, merge tmp space)
- checkout as normal

Note:
- there are [more things that can be dropped](https://github.com/easimon/maximize-build-space?tab=readme-ov-file#inputs), but this seems like enough
- this is somewhat temporary, if the disk usage goes over again