### PR TITLE
Fix attributeComparator default/primary attribute valueType

### DIFF
--- a/web/src/componentTable.js
+++ b/web/src/componentTable.js
@@ -30,6 +30,7 @@ function attributeComparator(x, y, valueType) {
     if (y === undefined)
         return -1;
     valueType ??= x.primary;
+    valueType ??= x.default;
     let comparator = quantityComparator(getQuantity(x.values[valueType]));
     return comparator(
         getValue(x.values[valueType]),


### PR DESCRIPTION
Looks like "primary" and "default" valueTypes are doing the same thing, but attributeComparator ignores "default" valueType. Fixes #135 