### PR TITLE
Fix empty descriptions (fix #151)

### DIFF
--- a/jlcparts/partLib.py
+++ b/jlcparts/partLib.py
@@ -39,7 +39,7 @@ def dbToComp(comp):
     comp["preferred"] = bool(comp["preferred"])
     return comp
 
-def fix_description(description, raw_extra_json):
+def fixDescription(description, raw_extra_json):
     """ Fix empty descriptions.
 
     At some point, JLC started returning empty descriptions in
@@ -65,7 +65,7 @@ class PartLibraryDb:
     def __init__(self, filepath=None):
         self.conn = sqlite3.connect(filepath)
         self.conn.row_factory = sqlite3.Row
-        self.conn.create_function("maybe_fix_description", 2, fix_description)
+        self.conn.create_function("maybeFixDescription", 2, fixDescription)
         self.transation = False
         self.categoryCache = {}
         self.manufacturerCache = {}
@@ -269,7 +269,7 @@ class PartLibraryDb:
 
         catId = self.getOrCreateCategoryId(component["category"], component["subcategory"])
         extra = json.dumps(c["extra"])
-        desc = fix_description(c["description"], extra)
+        desc = fixDescription(c["description"], extra)
 
         c = component
         data = [lcscToDb(c["lcsc"]), catId, c["mfr"], c["package"], c["joints"], manId,
@@ -298,7 +298,7 @@ class PartLibraryDb:
         self.conn.execute(f"""
             UPDATE components
             SET
-                description = maybe_fix_description(description, extra),
+                description = maybeFixDescription(description, extra),
                 last_update = ?
             WHERE
                 lcsc = ? AND
@@ -355,8 +355,8 @@ class PartLibraryDb:
         print("Fixing empty descriptions ... ")
         self.conn.execute("""
             UPDATE components
-            SET description = maybe_fix_description(description, extra)
-            WHERE description = '' OR description IS NULL""")
+            SET description = maybeFixDescription(description, extra)
+            WHERE description = ''""")
         self._commit()
 
     def categories(self):

--- a/jlcparts/partLib.py
+++ b/jlcparts/partLib.py
@@ -45,10 +45,9 @@ def fixDescription(description, raw_extra_json):
     At some point, JLC started returning empty descriptions in
     their parts CSV, but the description is still available in
     the 'extra' JSON in the 'description' field.
-    
-    This is a SQLite 'user defined function', the 'extra' here
-    is the raw extra column from the database, not the already
-    parsed 'extra' that is used elsewhere.
+
+    Note that this takes the raw JSON string, not the already
+    parsed 'extra' dict - this lets it be used as a SQLite UDF.
     """
 
     if not description:

--- a/jlcparts/partLib.py
+++ b/jlcparts/partLib.py
@@ -39,10 +39,33 @@ def dbToComp(comp):
     comp["preferred"] = bool(comp["preferred"])
     return comp
 
+def fix_description(description, raw_extra_json):
+    """ Fix empty descriptions.
+
+    At some point, JLC started returning empty descriptions in
+    their parts CSV, but the description is still available in
+    the 'extra' JSON in the 'description' field.
+    
+    This is a SQLite 'user defined function', the 'extra' here
+    is the raw extra column from the database, not the already
+    parsed 'extra' that is used elsewhere.
+    """
+
+    if not description:
+        try:
+            e = json.loads(raw_extra_json)
+            desc = e.get("description", "")
+            return desc
+        except Exception:
+            pass
+    return description
+
+
 class PartLibraryDb:
     def __init__(self, filepath=None):
         self.conn = sqlite3.connect(filepath)
         self.conn.row_factory = sqlite3.Row
+        self.conn.create_function("maybe_fix_description", 2, fix_description)
         self.transation = False
         self.categoryCache = {}
         self.manufacturerCache = {}
@@ -245,11 +268,13 @@ class PartLibraryDb:
         self.manufacturerCache[m] = manId
 
         catId = self.getOrCreateCategoryId(component["category"], component["subcategory"])
+        extra = json.dumps(c["extra"])
+        desc = fix_description(c["description"], extra)
 
         c = component
         data = [lcscToDb(c["lcsc"]), catId, c["mfr"], c["package"], c["joints"], manId,
-                c["basic"], c["description"], c["datasheet"], c["stock"],
-                json.dumps(c["price"]), int(time.time()), json.dumps(c["extra"])]
+                c["basic"], desc, c["datasheet"], c["stock"], json.dumps(c["price"]),
+                int(time.time()), extra]
         if flag is not None:
             data.append(flag)
         cur.execute(f"""
@@ -267,6 +292,18 @@ class PartLibraryDb:
             SET extra = ?, last_update = ?
             WHERE lcsc = ?
             """, (json.dumps(extra), int(time.time()), lcscToDb(lcsc)))
+        # The caller doesn't have the description, but a followon update
+        # can fix it if it was inserted as an empty string.  This sees
+        # the updated 'extra' column from the previous statement.
+        self.conn.execute(f"""
+            UPDATE components
+            SET
+                description = maybe_fix_description(description, extra),
+                last_update = ?
+            WHERE
+                lcsc = ? AND
+                description = ''
+        """, (int(time.time()), lcscToDb(lcsc)))
         self._commit()
 
     def updateJlcPart(self, component, flag=None):
@@ -312,6 +349,14 @@ class PartLibraryDb:
         cursor.execute("UPDATE components SET preferred = 0")
         cursor.execute(f"UPDATE components SET preferred = 1 WHERE lcsc IN ({','.join(len(lcscSet) * ['?'])})",
                        [lcscToDb(x) for x in lcscSet])
+        self._commit()
+
+    def fixEmptyDescriptions(self):
+        print("Fixing empty descriptions ... ")
+        self.conn.execute("""
+            UPDATE components
+            SET description = maybe_fix_description(description, extra)
+            WHERE description = '' OR description IS NULL""")
         self._commit()
 
     def categories(self):

--- a/jlcparts/ui.py
+++ b/jlcparts/ui.py
@@ -74,6 +74,14 @@ def updatePreferred(db):
     lib = PartLibraryDb(db)
     lib.setPreferred(preferred)
 
+@click.command()
+@click.argument("db", type=click.Path(dir_okay=False, writable=True))
+def fixDescriptions(db):
+    """
+    Fix empty descriptions in the database if the description is available in the JSON.
+    """
+    lib = PartLibraryDb(db)
+    lib.fixEmptyDescriptions()
 
 @click.command()
 @click.argument("libraryFilename")
@@ -169,6 +177,7 @@ cli.add_command(updatePreferred)
 cli.add_command(fetchDetails)
 cli.add_command(fetchTable)
 cli.add_command(testComponent)
+cli.add_command(fixDescriptions)
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
This fixes the issue of the missing descriptions in the database by copying the description from the
'extra' JSON, where the description still exists.

This is based on [this fix](https://github.com/Bouni/kicad-jlcpcb-tools/commit/75591ddf6f1e84af8c912b895a94cf53e985b12c) from Bouni/kicad-jlcpcb-tools for this issue.

I added a separate CLI command to fix the existing database descriptions, which it can do
without making additional calls to the API since the JSON is already there in the database for
most in-stock items.  The number of items with missing descriptions falls from 7 million to 3 million,
and only 125K if you filter against items that are in-stock.  On my laptop, it can fix the whole database
in about 3 minutes.


```
andrewmiller@Mac jlcparts % cp ../kicad-jlcpcb-tools/db_build/db_working/cache.sqlite3 /tmp/.
andrewmiller@Mac jlcparts % sqlite3 /tmp/cache.sqlite3 'select count(*) from components where descri
ption = ""'
7035948
andrewmiller@Mac jlcparts % time jlcparts fixdescriptions /tmp/cache.sqlite3
Fixing empty descriptions ...
jlcparts fixdescriptions /tmp/cache.sqlite3  25.02s user 52.75s system 45% cpu 2:50.63 total
andrewmiller@Mac jlcparts % sqlite3 /tmp/cache.sqlite3 'select count(*) from components where description = ""'
2944925
andrewmiller@Mac jlcparts % sqlite3 /tmp/cache.sqlite3 'select count(*) from components where description = "" and stock > 0'
125926
```

I tested the CLI command obviously, but I don't have an API key to test the changes I made that keep
the database up to date with new changes. 